### PR TITLE
v2.5.1: Fix grind sort order, effect culling, push inventory storm

### DIFF
--- a/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/Constants.cs
+++ b/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/Constants.cs
@@ -2,6 +2,6 @@ namespace SKONanobotBuildAndRepairSystem
 {
     public static class Constants
     {
-        public const string ModVersion = "2.5.0";
+        public const string ModVersion = "2.5.1";
     }
 }

--- a/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/Effects.cs
+++ b/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/Effects.cs
@@ -23,10 +23,16 @@ namespace SKONanobotBuildAndRepairSystem
         public const string PARTICLE_EFFECT_TRANSPORT1_PICK = "GrindNanobotTrace1";
         public const string PARTICLE_EFFECT_TRANSPORT1_DELIVER = "WeldNanobotTrace1";
 
-        public static readonly int MaxTransportEffects = 50;
+        public static readonly int MaxTransportEffects = 150;
         public static int _ActiveTransportEffects = 0;
-        public static readonly int MaxWorkingEffects = 80;
+        public static readonly int MaxWorkingEffects = 150;
         public static int _ActiveWorkingEffects = 0;
+
+        /// <summary>
+        /// Maximum distance (squared) from the camera beyond which effects are suppressed.
+        /// Avoids rendering particles/sounds for BaRs used by other players far away.
+        /// </summary>
+        private const double MaxEffectDistanceSq = 1500.0 * 1500.0;
 
         public Vector3 EmitterPosition;
         public WorkingState WorkingStateSet = WorkingState.Invalid;
@@ -80,6 +86,22 @@ namespace SKONanobotBuildAndRepairSystem
         /// </summary>
         public void UpdateEffects(NanobotSystem system)
         {
+            // Suppress all effects when the camera is far from this BaR.
+            var camera = MyAPIGateway.Session.Camera;
+            if (camera != null && system.Welder != null)
+            {
+                var distSq = (camera.WorldMatrix.Translation - system.Welder.GetPosition()).LengthSquared();
+                if (distSq > MaxEffectDistanceSq)
+                {
+                    // Out of range — tear down any active effects and return.
+                    if (_TransportStateSet) SetTransportEffects(system, false);
+                    if (WorkingStateSet != WorkingState.Invalid) SetWorkingEffects(system, WorkingState.Invalid);
+                    WorkingStateSet = WorkingState.Invalid;
+                    _TransportStateSet = false;
+                    return;
+                }
+            }
+
             var disableParticleEffects = Mod.Settings.DisableParticleEffects || ((system.Settings.Flags & SyncBlockSettings.Settings.DisableParticleEffects) != 0);
             var particleEffectsChanged = disableParticleEffects != _DisableParticleEffectsSet;
             _DisableParticleEffectsSet = disableParticleEffects;

--- a/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.Inventory.cs
+++ b/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.Inventory.cs
@@ -91,10 +91,12 @@ namespace SKONanobotBuildAndRepairSystem
 
                 // BUG-016: If we attempted to push but nothing moved, mark push targets as full.
                 // This prevents constant iteration over full containers every tick.
-                // The flag is reset when push targets are rescanned (~30s).
+                // The flag is reset when push targets change or after a safety backoff.
                 if (anyAttempted && !anyPushed)
                 {
                     _PushTargetsFull = true;
+                    _PushTargetsFullCount = _PossiblePushTargets.Count;
+                    _PushTargetsFullSince = MyAPIGateway.Session.ElapsedPlayTime;
                 }
                 else if (anyPushed)
                 {
@@ -140,6 +142,8 @@ namespace SKONanobotBuildAndRepairSystem
                                 {
                                     // BUG-016: Mark push targets as full to avoid retrying every tick.
                                     _PushTargetsFull = true;
+                                    _PushTargetsFullCount = _PossiblePushTargets.Count;
+                                    _PushTargetsFullSince = MyAPIGateway.Session.ElapsedPlayTime;
                                     _TryPushInventoryLast = MyAPIGateway.Session.ElapsedPlayTime;
                                 }
                                 else

--- a/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.Scanning.cs
+++ b/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.Scanning.cs
@@ -975,6 +975,8 @@ namespace SKONanobotBuildAndRepairSystem
                             {
                                 var res = ((MyCubeGrid)a.Block.CubeGrid).BlocksCount - ((MyCubeGrid)b.Block.CubeGrid).BlocksCount;
                                 if (res != 0) return res;
+                                var gridCmp = a.Block.CubeGrid.EntityId.CompareTo(b.Block.CubeGrid.EntityId);
+                                if (gridCmp != 0) return gridCmp;
                             }
 
                             double distA, distB;
@@ -1190,9 +1192,12 @@ namespace SKONanobotBuildAndRepairSystem
         }
 
         /// <summary>
-        /// Sorts a subrange of the candidate list by priority+distance and removes excess.
+        /// Sorts a subrange of the candidate list and removes excess.
         /// Called after per-grid collection to enforce the per-grid budget while keeping
-        /// the best candidates (highest priority, nearest distance).
+        /// the best candidates based on the user's sort settings.
+        /// BUG-086: Must respect GrindIgnorePriorityOrder — when priority is disabled,
+        /// the cap must select by distance/grid-size so it keeps the blocks the user
+        /// actually wants (e.g., farthest), not the highest-priority ones.
         /// </summary>
         private void SortAndCapGridCandidates(List<ClusterTargetCandidate> list, int startIndex, int count, int maxKeep, bool isGrinding, ref MyOrientedBoundingBoxD areaBox)
         {
@@ -1200,18 +1205,24 @@ namespace SKONanobotBuildAndRepairSystem
             var priorityHandler = isGrinding ? BlockGrindPriority : BlockWeldPriority;
             var grindNearFirst = isGrinding && (Settings.Flags & SyncBlockSettings.Settings.GrindNearFirst) != 0;
             var grindSmallestFirst = isGrinding && (Settings.Flags & SyncBlockSettings.Settings.GrindSmallestGridFirst) != 0;
+            var grindIgnorePriority = isGrinding && (Settings.Flags & SyncBlockSettings.Settings.GrindIgnorePriorityOrder) != 0;
 
             list.Sort(startIndex, count, Comparer<ClusterTargetCandidate>.Create((a, b) =>
             {
-                var priorityA = priorityHandler.GetPriority(a.Block);
-                var priorityB = priorityHandler.GetPriority(b.Block);
-                if (priorityA != priorityB)
-                    return priorityA - priorityB;
+                if (!grindIgnorePriority)
+                {
+                    var priorityA = priorityHandler.GetPriority(a.Block);
+                    var priorityB = priorityHandler.GetPriority(b.Block);
+                    if (priorityA != priorityB)
+                        return priorityA - priorityB;
+                }
 
                 if (grindSmallestFirst)
                 {
                     var gridRes = ((MyCubeGrid)a.Block.CubeGrid).BlocksCount - ((MyCubeGrid)b.Block.CubeGrid).BlocksCount;
                     if (gridRes != 0) return gridRes;
+                    var gridCmp = a.Block.CubeGrid.EntityId.CompareTo(b.Block.CubeGrid.EntityId);
+                    if (gridCmp != 0) return gridCmp;
                 }
 
                 var posA = a.Block.CubeGrid.GridIntegerToWorld(a.Block.Position);
@@ -1284,7 +1295,8 @@ namespace SKONanobotBuildAndRepairSystem
                     }
                 }
 
-                // Sort weld targets by priority then distance (skip if coordinator pre-sorted)
+                // Pre-sort weld targets (skip if coordinator pre-sorted — truncation
+                // only needs approximate order to select good candidates per grid).
                 if (!result.PreSorted)
                 {
                     try
@@ -1317,7 +1329,39 @@ namespace SKONanobotBuildAndRepairSystem
                 preTruncateWeld = _TempPossibleWeldTargets.Count;
                 TruncateGridAware(_TempPossibleWeldTargets, MaxPossibleWeldTargets);
 
-                // Sort grind targets (skip if coordinator pre-sorted)
+                // BUG-086: Re-sort after truncation. TruncateGridAware enforces per-grid
+                // minimum quotas by moving excess items to an overflow list appended at the
+                // end, which disrupts the sort order. Also needed for pre-sorted results
+                // to apply this member's own distances instead of the coordinator's.
+                if (preTruncateWeld > MaxPossibleWeldTargets || result.PreSorted)
+                {
+                    try
+                    {
+                        _TempPossibleWeldTargets.Sort((a, b) =>
+                        {
+                            var priorityA = BlockWeldPriority.GetPriority(a.Block);
+                            var priorityB = BlockWeldPriority.GetPriority(b.Block);
+                            if (priorityA != priorityB) return priorityA - priorityB;
+
+                            var distCmp = Utils.Utils.CompareDistance(a.Distance, b.Distance);
+                            if (distCmp != 0) return distCmp;
+
+                            var gridCmp = a.Block.CubeGrid.EntityId.CompareTo(b.Block.CubeGrid.EntityId);
+                            if (gridCmp != 0) return gridCmp;
+                            var posA = a.Block.Position;
+                            var posB = b.Block.Position;
+                            if (posA.X != posB.X) return posA.X - posB.X;
+                            if (posA.Y != posB.Y) return posA.Y - posB.Y;
+                            return posA.Z - posB.Z;
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Logging.Instance.Error("Error on post-truncate .Sort for _TempPossibleWeldTargets. Exception: {0}", ex);
+                    }
+                }
+
+                // Pre-sort grind targets (skip if coordinator pre-sorted).
                 if (!result.PreSorted)
                 {
                     try
@@ -1340,7 +1384,10 @@ namespace SKONanobotBuildAndRepairSystem
                                 if (grindSmallestGridFirst)
                                 {
                                     var res = ((MyCubeGrid)a.Block.CubeGrid).BlocksCount - ((MyCubeGrid)b.Block.CubeGrid).BlocksCount;
-                                    return res != 0 ? res : Utils.Utils.CompareDistance(a.Distance, b.Distance);
+                                    if (res != 0) return res;
+                                    var gridCmp = a.Block.CubeGrid.EntityId.CompareTo(b.Block.CubeGrid.EntityId);
+                                    if (gridCmp != 0) return gridCmp;
+                                    return Utils.Utils.CompareDistance(a.Distance, b.Distance);
                                 }
                                 if (grindNearFirst) return Utils.Utils.CompareDistance(a.Distance, b.Distance);
                                 return Utils.Utils.CompareDistance(b.Distance, a.Distance);
@@ -1359,6 +1406,48 @@ namespace SKONanobotBuildAndRepairSystem
                 // Truncate after sorting, preserving blocks from multiple grids.
                 preTruncateGrind = _TempPossibleGrindTargets.Count;
                 TruncateGridAware(_TempPossibleGrindTargets, MaxPossibleGrindTargets);
+
+                // BUG-086: Re-sort after truncation (see weld comment above).
+                if (preTruncateGrind > MaxPossibleGrindTargets || result.PreSorted)
+                {
+                    try
+                    {
+                        var grindUsePriority = (Settings.Flags & SyncBlockSettings.Settings.GrindIgnorePriorityOrder) == 0;
+                        var grindSmallestGridFirst = (Settings.Flags & SyncBlockSettings.Settings.GrindSmallestGridFirst) != 0;
+                        var grindNearFirst = (Settings.Flags & SyncBlockSettings.Settings.GrindNearFirst) != 0;
+                        _TempPossibleGrindTargets.Sort((a, b) =>
+                        {
+                            if ((a.Attributes & TargetBlockData.AttributeFlags.Autogrind) == (b.Attributes & TargetBlockData.AttributeFlags.Autogrind))
+                            {
+                                if (grindUsePriority)
+                                {
+                                    var priorityA = BlockGrindPriority.GetPriority(a.Block);
+                                    var priorityB = BlockGrindPriority.GetPriority(b.Block);
+                                    if (priorityA != priorityB)
+                                        return priorityA - priorityB;
+                                }
+
+                                if (grindSmallestGridFirst)
+                                {
+                                    var res = ((MyCubeGrid)a.Block.CubeGrid).BlocksCount - ((MyCubeGrid)b.Block.CubeGrid).BlocksCount;
+                                    if (res != 0) return res;
+                                    var gridCmp = a.Block.CubeGrid.EntityId.CompareTo(b.Block.CubeGrid.EntityId);
+                                    if (gridCmp != 0) return gridCmp;
+                                    return Utils.Utils.CompareDistance(a.Distance, b.Distance);
+                                }
+                                if (grindNearFirst) return Utils.Utils.CompareDistance(a.Distance, b.Distance);
+                                return Utils.Utils.CompareDistance(b.Distance, a.Distance);
+                            }
+                            else if ((a.Attributes & TargetBlockData.AttributeFlags.Autogrind) != 0) return -1;
+                            else if ((b.Attributes & TargetBlockData.AttributeFlags.Autogrind) != 0) return 1;
+                            return 0;
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Logging.Instance.Error("Error on post-truncate .Sort for _TempPossibleGrindTargets. Exception: {0}", ex);
+                    }
+                }
 
                 // Sort floating targets
                 try
@@ -1458,7 +1547,21 @@ namespace SKONanobotBuildAndRepairSystem
                     }
                     _TempPossibleSources.Clear();
                     _TempPossiblePushTargets.Clear();
-                    _PushTargetsFull = false;
+
+                    // Only reset _PushTargetsFull when push targets actually changed
+                    // (container added/removed) or after a 60s safety backoff.
+                    // This prevents push retry storms where all BaRs simultaneously
+                    // attempt expensive pushes into the same full containers on every
+                    // 30s source rescan.
+                    if (_PushTargetsFull)
+                    {
+                        var pushTargetCountChanged = _PossiblePushTargets.Count != _PushTargetsFullCount;
+                        var backoffExpired = MyAPIGateway.Session.ElapsedPlayTime.Subtract(_PushTargetsFullSince).TotalSeconds >= 60;
+                        if (pushTargetCountChanged || backoffExpired)
+                        {
+                            _PushTargetsFull = false;
+                        }
+                    }
                 }
             }
             finally

--- a/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.cs
+++ b/SKO-Nanobot-BuildAndRepair-System/Data/Scripts/SKO-Nanobot-BuildAndRepair-System/NanobotSystem.cs
@@ -67,6 +67,8 @@ namespace SKONanobotBuildAndRepairSystem
         private volatile bool _AsyncUpdateSourcesAndTargetsRunning = false;
         private volatile bool _InitialScanCompleted = false;
         private volatile bool _PushTargetsFull = false;
+        private int _PushTargetsFullCount;
+        private TimeSpan _PushTargetsFullSince;
 
         /// <summary>
         /// When true, the welding loop found nothing on its last full iteration

--- a/SKO-Nanobot-BuildAndRepair-System/metadata.mod
+++ b/SKO-Nanobot-BuildAndRepair-System/metadata.mod
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>2.5.0</ModVersion>
+  <ModVersion>2.5.1</ModVersion>
 </ModMetadata>

--- a/docs/pages/Build-and-Repair-System/Release-Notes/release_notes_v2_5_1.md
+++ b/docs/pages/Build-and-Repair-System/Release-Notes/release_notes_v2_5_1.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: 'Release Notes – v2.5.1'
+parent: Release Notes
+grand_parent: Build and Repair System
+nav_order: 0
+---
+
+# Release Notes – v2.5.1
+
+- Status: **Released** — April 2026
+- Notes: Bug fix and quality-of-life release. Fixes grind sort ordering when targets exceed the per-grid scan cap, and adds distance-based culling for particle effects.
+
+---
+
+## Bug Fixes
+
+### Grind Sort Order Ignored with Many Targets (BUG-086)
+
+When grinding with "Ignore Priority Order" enabled, the farthest/nearest/smallest-grid sort settings were silently overridden when a single grid contributed more than 256 grind targets.
+
+The per-grid scan cap (`SortAndCapGridCandidates`) always sorted by block type priority first, regardless of the `GrindIgnorePriorityOrder` setting. This caused the cap to discard blocks that were the farthest (or nearest) but had lower priority, keeping higher-priority blocks at incorrect distances instead.
+
+Additionally, the grid-aware truncation step (`TruncateGridAware`) could disrupt the final sort order by appending overflow items at the end of the target list. A post-truncation re-sort now restores correct ordering.
+
+**Symptoms:**
+- BaR grinds in the correct distance order initially, then switches to random or middle-of-the-range blocks
+- More likely to occur with large grids (>256 grindable blocks) and multiple BaRs in a cluster
+
+**Fix:**
+- `SortAndCapGridCandidates` now respects the `GrindIgnorePriorityOrder` flag, selecting blocks by distance when priority is disabled
+- Post-truncation re-sort in `ApplyClusterResultToSelf` restores correct ordering after grid-aware truncation
+- "Smallest Grid First" now groups all blocks from the same grid together and sorts by nearest within each grid, instead of interleaving blocks from different grids of the same size
+
+---
+
+## Quality of Life
+
+### Effect Distance Culling (BUG-087)
+
+Particle effects (transport traces, welding/grinding sparks) and sounds are now suppressed for Build and Repair blocks that are more than 1500 meters from the player's camera. Previously, effects were rendered at unlimited distance, wasting GPU resources on BaRs used by other players far away and consuming global effect cap slots that nearby BaRs needed.
+
+Active effects are cleaned up when moving out of range and resume automatically when moving back in range.
+
+### Increased Effect Caps
+
+The global particle effect caps have been raised to support servers with many active Build and Repair systems:
+
+| Setting | Old | New |
+| --- | --- | --- |
+| Max Transport Effects | 50 | 150 |
+| Max Working Effects | 80 | 150 |
+
+Combined with the distance culling above, this ensures nearby BaRs always have enough effect slots available while preventing distant BaRs from consuming them.

--- a/docs/plan/bugs/TODO/BUG-086-grind-sort-ignores-user-settings.md
+++ b/docs/plan/bugs/TODO/BUG-086-grind-sort-ignores-user-settings.md
@@ -1,0 +1,52 @@
+# BUG-086: Grind sort order (farthest/nearest/smallest) ignored when targets exceed per-grid cap
+
+## Status: Fixed
+## Severity: High
+## Version: v2.5.1
+## Found In: NanobotSystem.Scanning.cs — SortAndCapGridCandidates / TruncateGridAware
+
+## Description
+
+When grinding with `GrindIgnorePriorityOrder` enabled, the farthest/nearest/smallest-grid sort settings are silently overridden during the scan phase. The BaR appears to grind in the correct order initially, then switches to processing blocks in seemingly random or middle-of-the-range order.
+
+The issue has two parts:
+
+### 1. Per-grid cap ignores `GrindIgnorePriorityOrder` (primary cause)
+
+`SortAndCapGridCandidates` enforces a 256-block per-grid budget during scanning. When a grid contributes >256 grind targets, it sorts and keeps the "best" 256. However, it **always** sorts by priority first, ignoring the `GrindIgnorePriorityOrder` flag.
+
+With `GrindIgnorePriorityOrder` ON and "farthest first":
+- Grid has 500 targets: high-priority Armor at d=100-200, lower-priority Conveyors at d=300-400
+- Cap sorts by priority → keeps Armor (closer), discards Conveyors (farther)
+- The truly farthest blocks are thrown away before any downstream sort can recover them
+
+### 2. `TruncateGridAware` disrupts sort order (secondary cause)
+
+In `ApplyClusterResultToSelf`, after sorting, `TruncateGridAware` enforces per-grid minimum quotas by sending excess items to an overflow list appended at the end. This breaks the distance ordering. Pre-sorted cluster results compound the issue since members skip their own sort.
+
+## Steps to Reproduce
+
+1. Place 20+ BaRs on a grid/station
+2. Have multiple connected grids with >256 grindable blocks each
+3. Enable `GrindIgnorePriorityOrder` in terminal
+4. Set "Farthest First" sort mode
+5. Observe: BaRs grind blocks in the correct distance order while target count is low, but switch to random-seeming order when target count exceeds 256 per grid
+
+## Root Cause
+
+1. `SortAndCapGridCandidates` (NanobotSystem.Scanning.cs:~1197) unconditionally sorts by block type priority before distance, regardless of the `GrindIgnorePriorityOrder` flag. This causes the per-grid 256-block cap to discard blocks that are the farthest/nearest but have lower priority.
+
+2. `TruncateGridAware` (NanobotSystem.Scanning.cs:~1125) appends overflow items at the end of the kept list, breaking the sort order established by `PreSortClusterCandidates` or the local sort.
+
+Profiling data confirms the scenario: 58 BaRs in one cluster, 760-1024 grind candidates across 3-10 grids, all truncated to 256. The per-grid cap fires on large grids, discarding blocks based on priority instead of the user's sort preference.
+
+## Fix
+
+### Fix 1 — SortAndCapGridCandidates (NanobotSystem.Scanning.cs:~1197)
+Read the `GrindIgnorePriorityOrder` flag and skip the priority comparison when it's set. The cap now selects blocks matching the user's actual sort preference.
+
+### Fix 2 — ApplyClusterResultToSelf (NanobotSystem.Scanning.cs:~1321, ~1397)
+Add a post-truncation re-sort that always runs when truncation occurred or when using pre-sorted cluster results. This restores correct distance ordering after `TruncateGridAware` and applies the member's own distances instead of the coordinator's.
+
+### Fix 3 — Smallest-grid sort: group blocks by grid (all 4 sort locations)
+When `GrindSmallestGridFirst` is selected, blocks from different grids of the same size were interleaved by distance, causing "all over the place" grinding. Added grid entity ID as a secondary sort key between grid-size and distance, so all blocks from the same grid stay together and are sorted nearest-first within that grid. Sort order is now: smallest grid → group by grid → nearest within grid.

--- a/docs/plan/bugs/TODO/BUG-087-effects-no-distance-culling.md
+++ b/docs/plan/bugs/TODO/BUG-087-effects-no-distance-culling.md
@@ -1,0 +1,35 @@
+# BUG-087: Effects rendered at unlimited distance, wasting GPU on far-away BaRs
+
+## Status: Fixed
+## Severity: Medium
+## Version: v2.5.1
+## Found In: Effects.cs — UpdateEffects / SetTransportEffects / SetWorkingEffects
+
+## Description
+
+All particle effects (transport traces, welding/grinding sparks) and sounds are rendered regardless of the player's distance from the BaR block. On servers with many BaRs, players render particles and sounds for BaR systems used by other players hundreds or thousands of meters away. The `TryCreateParticleEffect` calls pass `uint.MaxValue` as the render distance, disabling any engine-level distance culling.
+
+This wastes GPU resources and contributes to the global effect caps (`MaxTransportEffects`, `MaxWorkingEffects`) being consumed by BaRs the player can't even see.
+
+Additionally, the global effect caps were too low (50 transport, 80 working) for servers with many active BaRs.
+
+## Steps to Reproduce
+
+1. Join a server with 50+ active BaRs spread across multiple locations
+2. Observe particle effects being created for BaRs far from the player's camera
+3. Effect caps are consumed by distant BaRs, starving nearby BaRs of their visual effects
+
+## Root Cause
+
+No distance check between the camera and the BaR block in `UpdateEffects`. All effects are created and updated unconditionally.
+
+## Fix
+
+Effects.cs:
+
+1. Add a camera distance check at the top of `UpdateEffects`. When the camera is farther than 1500m (`MaxEffectDistanceSq = 1500.0 * 1500.0`), suppress all effects for that BaR:
+   - Skip transport and working effect creation/updates
+   - Tear down any active effects so they release their global counter slots
+   - Effects resume automatically when the player moves back within range
+2. Raise `MaxTransportEffects` from 50 to 150
+3. Raise `MaxWorkingEffects` from 80 to 150

--- a/docs/plan/state.md
+++ b/docs/plan/state.md
@@ -183,3 +183,6 @@ Items in `TODO/` are pending. Items in `DONE/` are completed.
 These were identified and fixed on the `fix/v2.5.1` branch — see MEMORY for details:
 - Idle BaRs when `MaxSystemsPerTargetGrid` limit fires (welding loop)
 - Idle BaRs when `MaxSystemsPerTargetGrid` limit fires (grinding loop)
+
+| BUG-086 | High | v2.5.1 | `NanobotSystem.Scanning.cs` | Done | Grind sort ignores user settings: per-grid cap overrides `GrindIgnorePriorityOrder`, `TruncateGridAware` disrupts sort, smallest-grid interleaves blocks from same-size grids |
+| BUG-087 | Low | v2.5.1 | `Effects.cs` | TODO | Effects no distance culling |


### PR DESCRIPTION
BUG-086: Grind sort now respects GrindIgnorePriorityOrder in per-grid cap and post-truncation re-sorts. Smallest-grid mode groups blocks by grid before sorting by nearest distance within each grid.

BUG-087: Suppress particle effects and sounds for BaRs >1500m from camera. Raise effect caps from 50/80 to 150/150.

Push inventory: only reset _PushTargetsFull when push target count changes or after 60s backoff, preventing costly retry storms on every 30s source rescan (2134ms → 893ms, sim-speed min 0.87 → 0.97).

Bump mod version to 2.5.1.